### PR TITLE
SUP-2247: Update Tests and remove Tests from Shellcheck

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,4 +22,3 @@ steps:
           files:
             - hooks/**
             - lib/**
-            - tests/**

--- a/README.md
+++ b/README.md
@@ -1,30 +1,29 @@
 # Lacework Buildkite Plugin [![Build status](https://badge.buildkite.com/9f3a0547e51013ba853112588042c39f081fc09937ddae031f.svg)](https://buildkite.com/buildkite/plugins-lacework)
 
 A Buildkite plugin that integrates with [Lacework](https://www.lacework.com/).
-If you need to start a Lacework trial, [click here](https://aws.amazon.com/marketplace/pp/prodview-wcor2dssgwok6) 
+If you need to start a Lacework trial, [click here](https://aws.amazon.com/marketplace/pp/prodview-wcor2dssgwok6)
 
 ## Initial Configuration
 
 It's necesary to have the [Lacework CLI](https://docs.lacework.net/cli/) installed on the compute running the buildkite agent(s) so you can see the results. The necessary components must be installed as well, install links below:
-- SCA Scanning (Software Composition Analysis) (https://docs.lacework.net/iac/restricted/iac-cli#configure-the-cli-for-iac)
-- SAST Scanning (Static Application Security Testing) (https://docs.lacework.net/codesecurity/restricted/sast-lw-cli#install-the-sast-component)
-- Container Vulnerability Scanning (https://docs.lacework.net/console/local-scanning-quickstart#get-started-with-the-lacework-cli)
-- IAC Scanning (Infrastructure As Code) (https://docs.lacework.net/iac/restricted/iac-cli#configure-the-cli-for-iac)
 
-Docker is also needed for vulnerability scans. Make sure you are licensed for the right scanning type. If you are not sure about the right entitlements, contact your Lacework representative or support@lacework.net.
+- SCA Scanning (Software Composition Analysis) (<https://docs.lacework.net/iac/restricted/iac-cli#configure-the-cli-for-iac>)
+- SAST Scanning (Static Application Security Testing) (<https://docs.lacework.net/codesecurity/restricted/sast-lw-cli#install-the-sast-component>)
+- Container Vulnerability Scanning (<https://docs.lacework.net/console/local-scanning-quickstart#get-started-with-the-lacework-cli>)
+- IAC Scanning (Infrastructure As Code) (<https://docs.lacework.net/iac/restricted/iac-cli#configure-the-cli-for-iac>)
 
+Docker is also needed for vulnerability scans. Make sure you are licensed for the right scanning type. If you are not sure about the right entitlements, contact your Lacework representative or <support@lacework.net>.
 
 ## Authentication with Lacework
 
 Your API key and secret should be available to the job [as any other secret](https://buildkite.com/docs/pipelines/secrets) through a secret manager or environment hook. The value for these secrets can be obtained by following [the corresponding instructions to create a Lacework API key](https://docs.lacework.net/console/api-access-keys).
-A separate Authorization token will be needed in place of the API key and secret just for vulnerability scans and can be obtained as such (https://docs.lacework.net/onboarding/integrate-inline-scanner#create-an-inline-scanner-integration-in-the-lacework-console)
+A separate Authorization token will be needed in place of the API key and secret just for vulnerability scans and can be obtained as such (<https://docs.lacework.net/onboarding/integrate-inline-scanner#create-an-inline-scanner-integration-in-the-lacework-console>)
 
 There are three ways to authenticate the plug-in with Lacework:
-1. Setup a Lacework profile on the compute instance running the job and set the "profile" configuration option under steps. To setup the profile - https://docs.lacework.net/cli/commands/lacework_configure/. For IAC there is an IAC profile which can be setup like this - https://docs.lacework.net/iac/restricted/iac-cli#configure-the-cli
+
+1. Setup a Lacework profile on the compute instance running the job and set the "profile" configuration option under steps. To setup the profile - <https://docs.lacework.net/cli/commands/lacework_configure/>. For IAC there is an IAC profile which can be setup like this - <https://docs.lacework.net/iac/restricted/iac-cli#configure-the-cli>
 2. Use default environment variables setup on the compute running the buildkite jobs. These variables are LW_API_KEY, LW_API_SECRET. This will not work for vulnerability scans since we are using a separate auth token
 3. Pass the API key and secret, or vulnerability authorization token to the Buildkite job with these variables BUILDKITE_PLUGIN_LACEWORK_API_KEY_ENV_VAR (LW API Key), BUILDKITE_PLUGIN_LACEWORK_API_KEY_SECRET_ENV_VAR (LW API Secret), BUILDKITE_PLUGIN_LACEWORK_ACCESS_TOKEN_ENV_VAR (auth token for vuln scans). As mentioned above this can be done with a secrets manager or passing those to the buildkute build under "environment variables" in the options
-
-
 
 These are the available configuration options for the plugin:
 
@@ -56,7 +55,7 @@ Name of the environment variable that contains the Vuln scan acces token. Only v
 
 Only valid for IAC and Vuln scans. Sets the fail level from info, low, medium, high, critical and fails the build with an exit code of 1 if such vulnerabilities/misconfigurations are found
 
-#### ` vulnerability-scan-tag` (string)
+#### `vulnerability-scan-tag` (string)
 
 Only valid for vulnerability scans. The image tag to scan.
 
@@ -67,8 +66,6 @@ Only valid for vulnerability scans. The image repository to scan.
 #### `iac-scan-type` (enum)
 
 Only valid for iac. Choose from  "cloudformation-scan", "kubernetes-scan", "helm-scan","terraform-scan", "kustomize-scan", "secrets-scan"
-
-
 
 ## Examples
 
@@ -124,6 +121,6 @@ steps:
           vulnerability-scan-tag: "latest"
 ```
 
-
 ## Support
-For support or any issues, please reach out to tech-alliances@lacework.net
+
+For support or any issues, please reach out to <tech-alliances@lacework.net>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,8 @@ services:
     image: buildkite/plugin-tester:v4.1.1
     volumes:
       - ".:/plugin:ro"
+  lint:
+    image: buildkite/plugin-linter
+    command: ['--id', 'lacework']
+    volumes:
+      - ".:/plugin:ro"

--- a/lib/lacework.bash
+++ b/lib/lacework.bash
@@ -5,9 +5,9 @@ set -euo pipefail
 function configure_plugin() {
 
     # required options
-    export ACCOUNT_NAME="${BUILDKITE_PLUGIN_LACEWORK_ACCOUNT_NAME:-}"
+    ACCOUNT_NAME="${BUILDKITE_PLUGIN_LACEWORK_ACCOUNT_NAME:-}"
 
-    export SCAN_TYPE="${BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE:-}"
+    SCAN_TYPE="${BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE:-}"
 
     #validate required options
     if [ -z "${ACCOUNT_NAME}" ]; then
@@ -23,20 +23,20 @@ function configure_plugin() {
 
     #other options
 
-    export API_KEY_ENV_VAR="${BUILDKITE_PLUGIN_LACEWORK_API_KEY_ENV_VAR:-}"
+    API_KEY_ENV_VAR="${BUILDKITE_PLUGIN_LACEWORK_API_KEY_ENV_VAR:-}"
 
-    export API_KEY_SECRET_ENV_VAR="${BUILDKITE_PLUGIN_LACEWORK_API_KEY_SECRET_ENV_VAR:-}"
+    API_KEY_SECRET_ENV_VAR="${BUILDKITE_PLUGIN_LACEWORK_API_KEY_SECRET_ENV_VAR:-}"
 
     #if LW_API_KEY is defined locally, use that if the buildkite environment variable is absent
     if [ -z "${API_KEY_ENV_VAR}" ]; then
-        export API_KEY_ENV_VAR="${LW_API_KEY:-}"
+        API_KEY_ENV_VAR="${LW_API_KEY:-}"
     fi
     #if LW_API_SECRET is defined locally, use that if the buildkite environment variable is absent
     if [ -z "${API_KEY_SECRET_ENV_VAR}" ]; then
-        export API_KEY_SECRET_ENV_VAR="${LW_API_SECRET:-}"
+        API_KEY_SECRET_ENV_VAR="${LW_API_SECRET:-}"
     fi
 
-    export PROFILE="${BUILDKITE_PLUGIN_LACEWORK_PROFILE:-}"
+    PROFILE="${BUILDKITE_PLUGIN_LACEWORK_PROFILE:-}"
 
     #if profile is defined locally, use that if the buildkite environment variable is absent - not applicable for vuln scans
     if [ -z "${API_KEY_ENV_VAR}" ] || [ -z "${API_KEY_SECRET_ENV_VAR}" ]; then
@@ -49,10 +49,10 @@ function configure_plugin() {
 
     # need to export the below ENV variables for IAC to work since you can't pass those via CLI
     if [ "${SCAN_TYPE}" == "iac" ]; then
-        export IAC_SCAN_TYPE="${BUILDKITE_PLUGIN_LACEWORK_IAC_SCAN_TYPE:-}"
-        export LW_ACCOUNT="${ACCOUNT_NAME}"
-        export LW_API_KEY="${API_KEY_ENV_VAR}"
-        export LW_API_SECRET="${API_KEY_SECRET_ENV_VAR}"
+        IAC_SCAN_TYPE="${BUILDKITE_PLUGIN_LACEWORK_IAC_SCAN_TYPE:-}"
+        LW_ACCOUNT="${ACCOUNT_NAME}"
+        LW_API_KEY="${API_KEY_ENV_VAR}"
+        LW_API_SECRET="${API_KEY_SECRET_ENV_VAR}"
 
         if [ -z "${IAC_SCAN_TYPE}" ] || [ -z "${LW_ACCOUNT}" ] || [ -z "${LW_API_KEY}" ] || [ -z "${LW_API_SECRET}" ]; then
             if [ -z "${PROFILE}" ]; then
@@ -64,16 +64,16 @@ function configure_plugin() {
 
     #vuln scan related env variables
     if [ "${SCAN_TYPE}" == "vulnerability" ]; then
-        export ACCESS_TOKEN_ENV_VAR="${BUILDKITE_PLUGIN_LACEWORK_ACCESS_TOKEN_ENV_VAR:-}"
-        export VULNERABILITY_SCAN_REPOSITORY="${BUILDKITE_PLUGIN_LACEWORK_VULNERABILITY_SCAN_REPOSITORY:-}"
-        export VULNERABILITY_SCAN_TAG="${BUILDKITE_PLUGIN_LACEWORK_VULNERABILITY_SCAN_TAG:-}"
+        ACCESS_TOKEN_ENV_VAR="${BUILDKITE_PLUGIN_LACEWORK_ACCESS_TOKEN_ENV_VAR:-}"
+        VULNERABILITY_SCAN_REPOSITORY="${BUILDKITE_PLUGIN_LACEWORK_VULNERABILITY_SCAN_REPOSITORY:-}"
+        VULNERABILITY_SCAN_TAG="${BUILDKITE_PLUGIN_LACEWORK_VULNERABILITY_SCAN_TAG:-}"
         if [ -z "${ACCESS_TOKEN_ENV_VAR}" ] || [ -z "${VULNERABILITY_SCAN_REPOSITORY}" ] || [ -z "${VULNERABILITY_SCAN_TAG}" ]; then
             echo "ERROR: Missing config related to vulnerability scans. Need the following: ACCESS_TOKEN_ENV_VAR, VULNERABILITY_SCAN_REPOSITORY, VULNERABILITY_SCAN_TAG" >&2
             exit 1
         fi
     fi
 
-    export FAIL_LEVEL="${BUILDKITE_PLUGIN_LACEWORK_FAIL_LEVEL:-}"
+    FAIL_LEVEL="${BUILDKITE_PLUGIN_LACEWORK_FAIL_LEVEL:-}"
 
 }
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -71,6 +71,7 @@ setup() {
   run "${PWD}"/hooks/command
 
   assert_success
+  assert_output --partial "SCA Scan"
 
   unstub lacework
 
@@ -85,6 +86,7 @@ setup() {
   run "${PWD}"/hooks/command
 
   assert_success
+  assert_output --partial "SCA Scan"
 
   unstub lacework
 }
@@ -132,6 +134,7 @@ setup() {
   run "${PWD}"/hooks/command
 
   assert_success
+  assert_output --partial "IAC Scan"
 
   unstub lacework
 }
@@ -148,6 +151,7 @@ setup() {
   run "${PWD}"/hooks/command
 
   assert_success
+  assert_output --partial "IAC Scan"
 
   unstub lacework
 }
@@ -174,6 +178,7 @@ setup() {
   run "${PWD}"/hooks/command
 
   assert_success
+  assert_output --partial "Vuln Scan"
 
   unstub lacework
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 
-# TODO: Revisit lacework.bash and tests to correct shellcheck on exports statements
-# shellcheck disable=SC2030,SC2031 
-
 # export LACEWORK_STUB_DEBUG=/dev/tty
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -64,7 +64,6 @@ setup() {
   unset BUILDKITE_PLUGIN_LACEWORK_API_KEY_ENV_VAR
   export BUILDKITE_PLUGIN_LACEWORK_PROFILE="default"
 
-  export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='sca'
   stub lacework \
     "--profile default sca scan . --save-results : echo 'SCA Scan'"
 
@@ -74,12 +73,10 @@ setup() {
   assert_output --partial "SCA Scan"
 
   unstub lacework
-
 }
 
 @test 'Lacework SCA SCAN' {
 
-  export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='sca'
   stub lacework \
     "--account myaccount --api_key key1234 --api_secret secret1234 sca scan . --save-results : echo 'SCA Scan'"
 
@@ -93,9 +90,6 @@ setup() {
 
 @test 'Lacework SAST SCAN' {
   export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='sast'
-
-  export BUILDKITE_PIPELINE_SLUG='slug'
-  export BUILDKITE_BUILD_NUMBER='123'
 
   stub lacework \
     "--account myaccount --api_key key1234 --api_secret secret1234 sast scan -o lacework-sast-report-pipeline-slug-3.sarif : echo 'SAST Scan'"
@@ -116,7 +110,6 @@ setup() {
 }
 
 @test 'Lacework IAC SCAN missing IAC scan type' {
-
   export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='iac'
 
   run "${PWD}"/hooks/command
@@ -126,7 +119,6 @@ setup() {
 }
 
 @test 'Lacework IAC SCAN' {
-
   export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='iac'
   export BUILDKITE_PLUGIN_LACEWORK_IAC_SCAN_TYPE='kubernetes-scan'
 
@@ -163,7 +155,6 @@ setup() {
   run "${PWD}"/hooks/command
 
   assert_failure
-
   assert_output --partial "ERROR: Missing config related to vulnerability scans"
 }
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -15,29 +15,46 @@ setup() {
 @test 'Missing  API key environment variable' {
   unset BUILDKITE_PLUGIN_LACEWORK_API_KEY_ENV_VAR
 
+  stub buildkite-agent \
+    "annotate * --style error --context lacework : echo 'buildkite-agent: Error Annotation'"
+
   run "${PWD}"/hooks/command
 
   assert_failure
-  assert_output --partial 'ERROR: Missing Lacework API Key and Secret'
+  assert_output --partial "ERROR: Missing Lacework API Key and Secret or profile"
+  assert_output --partial "buildkite-agent: Error Annotation"
 
+  unstub buildkite-agent
 }
 
 @test 'Missing API key secret environment variable' {
   unset BUILDKITE_PLUGIN_LACEWORK_API_KEY_SECRET_ENV_VAR
 
+  stub buildkite-agent \
+    "annotate * --style error --context lacework : echo 'buildkite-agent: Error Annotation'"
+
   run "${PWD}"/hooks/command
 
   assert_failure
   assert_output --partial 'ERROR: Missing Lacework API Key and Secret'
+  assert_output --partial "buildkite-agent: Error Annotation"
 
+  unstub buildkite-agent
 }
 
 @test "Error if no account name was set" {
   unset BUILDKITE_PLUGIN_LACEWORK_ACCOUNT_NAME
-  run "$PWD/hooks/command"
+
+  stub buildkite-agent \
+    "annotate * --style error --context lacework : echo 'buildkite-agent: Error Annotation'"
+
+  run "${PWD}"/hooks/command
 
   assert_failure
   assert_output --partial "ERROR: Missing required config 'account-name'"
+  assert_output --partial "buildkite-agent: Error Annotation"
+
+  unstub buildkite-agent
 }
 
 @test 'PROFILE test SCA' {

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -92,25 +92,27 @@ setup() {
 }
 
 @test 'Lacework SAST SCAN' {
-
   export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='sast'
 
   export BUILDKITE_PIPELINE_SLUG='slug'
   export BUILDKITE_BUILD_NUMBER='123'
 
   stub lacework \
-    "--account myaccount --api_key key1234 --api_secret secret1234 sast scan -o lacework-sast-report-slug-123.sarif : echo 'SAST Scan'"
+    "--account myaccount --api_key key1234 --api_secret secret1234 sast scan -o lacework-sast-report-pipeline-slug-3.sarif : echo 'SAST Scan'"
 
-  #stub buildkite-agent \
-  #"artifact upload  lacework-sast-report-slug-123.sarif : echo 'SAST Scan Artifact'"
+  stub buildkite-agent \
+    "artifact upload lacework-sast-report-pipeline-slug-3.sarif : echo 'buildkite-agent: SAST Scan Artifact'" \
+    "annotate * --style success --context lacework-sast : echo 'buildkite-agent: SAST Scan Annotation'"
 
   run "${PWD}"/hooks/command
 
-  #assert_success
+  assert_success
   assert_output --partial "SAST Scan"
+  assert_output --partial "buildkite-agent: SAST Scan Artifact"
+  assert_output --partial "buildkite-agent: SAST Scan Annotation"
 
   unstub lacework
-  #unstub buildkite-agent
+  unstub buildkite-agent
 }
 
 @test 'Lacework IAC SCAN missing IAC scan type' {

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -10,6 +10,8 @@ setup() {
   export BUILDKITE_PLUGIN_LACEWORK_API_KEY_SECRET_ENV_VAR=secret1234
   export BUILDKITE_PLUGIN_LACEWORK_ACCOUNT_NAME='myaccount'
   export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='sca'
+  export BUILDKITE_PIPELINE_SLUG='pipeline-slug'
+  export BUILDKITE_BUILD_NUMBER=3
 }
 
 @test 'Missing  API key environment variable' {
@@ -60,7 +62,7 @@ setup() {
 @test 'PROFILE test SCA' {
   unset BUILDKITE_PLUGIN_LACEWORK_API_KEY_SECRET_ENV_VAR
   unset BUILDKITE_PLUGIN_LACEWORK_API_KEY_ENV_VAR
-  export BUILDKITE_PLUGIN_LACEWORK_PROFILE=default
+  export BUILDKITE_PLUGIN_LACEWORK_PROFILE="default"
 
   export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='sca'
   stub lacework \
@@ -151,8 +153,7 @@ setup() {
 }
 
 @test 'Lacework VULN SCAN missing environment variables' {
-
-  BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='vulnerability'
+  export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='vulnerability'
 
   run "${PWD}"/hooks/command
 
@@ -162,8 +163,7 @@ setup() {
 }
 
 @test 'Lacework VULN SCAN' {
-
-  BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='vulnerability'
+  export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='vulnerability'
   export BUILDKITE_PLUGIN_LACEWORK_ACCESS_TOKEN_ENV_VAR='mytoken1234'
   export BUILDKITE_PLUGIN_LACEWORK_VULNERABILITY_SCAN_REPOSITORY='myrepo'
   export BUILDKITE_PLUGIN_LACEWORK_VULNERABILITY_SCAN_TAG='latest'

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -139,8 +139,7 @@ setup() {
   unstub lacework
 }
 
-@test 'Lacework IAC SCAN with fail' {
-
+@test 'Lacework IAC SCAN with fail level set' {
   export BUILDKITE_PLUGIN_LACEWORK_SCAN_TYPE='iac'
   export BUILDKITE_PLUGIN_LACEWORK_IAC_SCAN_TYPE='kubernetes-scan'
   export BUILDKITE_PLUGIN_LACEWORK_FAIL_LEVEL='critical'


### PR DESCRIPTION
Updating tests to fix stubs and asserts of outputs but removing `tests/*` directory from Shellcheck as to match other Plugins and there will be cases where tests may have to be setup in ways that will fail Shellchecks