### PR TITLE
Remove explicit targeting of the hosted queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,22 +1,16 @@
 steps:
   - label: ":shell: Tests"
-    agents:
-      queue: "hosted"
     plugins:
       - plugin-tester#v1.1.1:
           folders:
             - tests
 
   - label: ":sparkles: Lint"
-    agents:
-      queue: "hosted"
     plugins:
       - plugin-linter#v3.3.0:
           id: lacework
 
   - label: ":shell: Shellcheck"
-    agents:
-      queue: "hosted"
     plugins:
       - shellcheck#v1.3.0:
           files:


### PR DESCRIPTION
Same premise as [this](https://github.com/buildkite-plugins/vault-secrets-buildkite-plugin/pull/57) - queue is now defaulted